### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Test with Maven
-        run: mvn clean test jacoco:report
+        run: mvn clean test jacoco:report -DdisableXmlReport=true
       - name: Codecov
         uses: codecov/codecov-action@v3.1.0
         with:


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -DdisableXmlReport=true to the mvn command.